### PR TITLE
Add Markdown table RTL fix, extension update flow, and visual regression tooling

### DIFF
--- a/.cursor/skills/cursor-rtl-visual-fix/SKILL.md
+++ b/.cursor/skills/cursor-rtl-visual-fix/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: cursor-rtl-visual-fix
+description: Fix Cursor RTL rendering issues end-to-end with visual verification. Use when the user provides a cursor-ext-rtl GitHub issue, mentions RTL visual bugs, Markdown tables, Hebrew/Arabic/Persian layout, Cursor chat rendering, or asks to develop and visually test a fix.
+---
+
+# Cursor RTL Visual Fix
+
+Use this skill to take an RTL rendering issue from report to verified fix in this repository.
+
+## Operating Rules
+
+- Treat the issue screenshot/description as the product requirement.
+- Do not commit or push unless the user explicitly asks.
+- Use `npm run package` to create a VSIX. Do not run `vsce package` directly.
+- Preserve unrelated user changes. Do not revert files you did not need to touch.
+- Visual evidence is required for UI/layout fixes. DOM checks are supporting evidence only.
+- Never approve or update visual baselines without explicit user confirmation after they review `visual/actual`.
+
+## End-to-End Workflow
+
+1. Understand the issue.
+   - If given a GitHub issue URL, use `gh issue view <number> --repo motcke/cursor-ext-rtl --comments` when possible.
+   - Extract the failing scenario, expected layout, actual layout, affected UI surface, and any screenshot clues.
+   - For example, issue `#8` is about mixed Hebrew and English text being misaligned in Markdown tables.
+
+2. Inspect the current implementation.
+   - Start with `resources/rtl.js`; most visual behavior is injected from there.
+   - Check related selectors, direction rules, `unicode-bidi`, `text-align`, table handling, code block exclusions, and scanner behavior.
+   - Search before editing. Prefer the repo's existing CSS/DOM-injection patterns.
+
+3. Reproduce visually in real Cursor.
+   - Cursor must be launched with CDP:
+
+```powershell
+& "$env:LOCALAPPDATA\Programs\cursor\Cursor.exe" --remote-debugging-port=9222
+```
+
+   - If `http://localhost:9222/json` is unavailable, stop and ask the user to relaunch Cursor with the flag.
+   - Use the real Cursor chat/composer to create or locate a scenario matching the issue. For table issues, use a Markdown table containing mixed Hebrew and English.
+
+4. Implement the smallest fix.
+   - Prefer targeted changes in `resources/rtl.js`.
+   - Keep code blocks and editor internals LTR.
+   - Avoid broad `direction: rtl` rules on large containers unless the issue proves that is necessary.
+   - Prefer CSS logical properties and per-element direction behavior over hard-coded left/right when possible.
+
+5. Build and package.
+   - Run `npm run lint`.
+   - Run `npm run package` when a VSIX/reinstall is needed.
+   - If the fix requires the Cursor patch to reload, install/reapply the extension and restart/reload Cursor as the repository workflow requires.
+
+6. Capture visual evidence.
+   - Run:
+
+```powershell
+npm run visual:capture
+```
+
+   - Review these artifacts:
+     - `visual/actual/cursor-right-pane.png`
+     - `visual/actual/cursor-full.png`
+     - `visual/actual/cursor-inspection.json`
+   - Use `VISUAL_CLIP` if the right pane crop is not focused enough:
+
+```powershell
+$env:VISUAL_CLIP = "900,80,700,900"
+npm run visual:capture
+Remove-Item Env:\VISUAL_CLIP
+```
+
+7. Compare against baseline.
+   - If a baseline already exists, run:
+
+```powershell
+npm run visual
+```
+
+   - If comparison fails, inspect `visual/diff`.
+   - Only ask the user to approve a new baseline after explaining what changed and why it is expected:
+
+```powershell
+npm run visual:approve
+```
+
+8. Report results.
+   - Include the issue summary, root cause, implementation approach, and visual verification result.
+   - Mention whether `npm run lint`, `npm run package`, `npm run visual:capture`, and `npm run visual` passed.
+   - If visual approval is still needed, say exactly which image the user should review.
+
+## Visual Reproduction Prompts
+
+Use issue-specific content in Cursor chat. For Markdown table alignment, a useful prompt is:
+
+```markdown
+תציג לי טבלת Markdown עם עמודות:
+| שדה | English value | הערות |
+|-----|---------------|-------|
+| שם משתמש | userName | טקסט בעברית mixed with English |
+| סטטוס | active | בדיקה עם API ו-JSON |
+| נתיב | C:\repos\cursor-ext-rtl | נתיב צריך להישאר LTR |
+```
+
+For code block regressions, include Hebrew prose plus fenced code. The prose should behave RTL; code should remain LTR.
+
+## Root-Cause Checklist
+
+Before fixing, identify which category applies:
+
+- Selector miss: the affected UI element is not covered by `DIR_SELECTOR` or CSS.
+- Over-broad direction: a parent/container forces the wrong direction.
+- Table layout: table container, table, cell, or inline content has conflicting `direction`/`text-align`.
+- Mixed inline text: `unicode-bidi`, `dir="auto"`, or `plaintext` is missing or applied at the wrong level.
+- Exclusion problem: code/editor/mermaid/table internals are being scanned when they should not be.
+- Timing problem: content appears after initial scans and the MutationObserver does not catch it.
+
+## When Playwriter Fits
+
+Use Playwriter for browser-side helpers such as viewing a generated report, opening GitHub pages, or inspecting external web content. Do not rely on Playwriter to capture Cursor itself; Cursor screenshots come from the CDP workflow and `npm run visual:capture`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 *.vsix
+visual/actual/
+visual/diff/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Smart multi-language RTL support for [Cursor](https://cursor.com) AI Chat. Uses 
 - **One-click Enable/Disable** via Command Palette
 - **Status Bar indicator** showing current RTL patch state (ON / OFF / UPDATE NEEDED)
 - **Automatic update detection** when Cursor updates overwrite `main.js`
+- **Extension update checks** with release-page and VSIX download shortcuts
 - **Auto re-apply option** to silently re-apply after Cursor updates
+- **Markdown table support** for mixed RTL/LTR table content
 - **Transactional patching** with automatic backup and rollback on failure
 - **Cross-platform** support for Windows, macOS, and Linux
 
@@ -46,6 +48,7 @@ Smart multi-language RTL support for [Cursor](https://cursor.com) AI Chat. Uses 
 | `Cursor RTL: Disable RTL Support` | Restore `main.js` from backup, remove `rtl.js` |
 | `Cursor RTL: Check Status` | Show whether the RTL patch is currently active |
 | `Cursor RTL: Re-apply After Update` | Re-apply patch after a Cursor update overwrote it |
+| `Cursor RTL: Check for Extension Updates` | Check GitHub releases for a newer extension version |
 
 ## Status Bar
 
@@ -61,11 +64,14 @@ Click the status bar item for a quick-pick menu with available actions.
 |---------|---------|-------------|
 | `cursorRtl.autoReapply` | `false` | Automatically re-apply RTL patch when Cursor updates overwrite `main.js` |
 | `cursorRtl.showStatusBar` | `true` | Show RTL status indicator in the status bar |
+| `cursorRtl.checkForExtensionUpdates` | `true` | Automatically check GitHub releases for Cursor RTL extension updates |
+| `cursorRtl.updateCheckIntervalHours` | `6` | How often to check for extension updates while Cursor is open |
+| `cursorRtl.updateRemindLaterHours` | `24` | How long to wait before showing the same update again after choosing Remind Later |
 
 ## Installation
 
 1. Download the latest `.vsix` from the [Releases page](https://github.com/motcke/cursor-ext-rtl/releases)
-2. In Cursor, open the Extensions view (`Ctrl+Shift+X`) → click the `...` menu (top-right) → select **Install from VSIX...** → choose the downloaded file
+2. In Cursor, press `Ctrl+Shift+P` to open the Command Palette → search for `VSIX` → select **Extensions: Install from VSIX...** → choose the downloaded file
 3. Look for **"RTL: OFF"** on the right side of the bottom status bar → click it → select **Enable RTL**
 4. Approve the installation → close and reopen **all** Cursor windows
 
@@ -106,6 +112,36 @@ This restores the original `main.js` from the backup and removes the `rtl.js` fi
 ## Supported Cursor Versions
 
 Compatible with Cursor 2.4.37+ (uses `app.on('browser-window-created')` pattern).
+
+## Development
+
+Visual checks can capture and compare the real Cursor UI for RTL layout regressions:
+
+```powershell
+npm run visual:capture
+npm run visual:compare
+```
+
+See [`visual/README.md`](visual/README.md) for the full workflow and privacy notes.
+
+## Privacy and Telemetry
+
+Cursor RTL collects telemetry for the sole purpose of improving the extension, understanding failures, and maintaining compatibility with Cursor updates. Telemetry is enabled by default.
+
+The extension may send usage events such as extension startup/shutdown, patch apply/remove/reapply, status checks, update detection, and version availability. These events may include diagnostic environment details such as Cursor version, release channel, patch state, platform, architecture, locale, timezone, hostname, OS username, and home directory. The extension does not intentionally send workspace file contents, editor text, or clipboard contents.
+
+### Opt out
+
+Telemetry can be disabled with an advanced environment variable before launching Cursor:
+
+```powershell
+$env:CURSOR_RTL_TELEMETRY_OPTOUT = "1"
+& "$env:LOCALAPPDATA\Programs\cursor\Cursor.exe"
+```
+
+Persistent opt-out can be configured at the operating system level by setting `CURSOR_RTL_TELEMETRY_OPTOUT=1` for the user or machine environment. `CURSOR_RTL_DISABLE_TELEMETRY=1` is also supported.
+
+Debug loader logs are disabled by default. If you explicitly enable `CURSOR_RTL_DEBUG_LOG=1`, a debug log may be written to the system temp directory, but it avoids recording Cursor window URLs and full local paths.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-rtl",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-rtl",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "applicationinsights": "^3.14.0"
@@ -15,7 +15,10 @@
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
         "@vscode/vsce": "^3.0.0",
-        "esbuild": "^0.24.0",
+        "esbuild": "^0.28.0",
+        "pixelmatch": "^7.2.0",
+        "playwright": "^1.59.1",
+        "pngjs": "^7.0.0",
         "typescript": "^5.5.0"
       },
       "engines": {
@@ -469,9 +472,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -486,9 +489,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -503,9 +506,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -520,9 +523,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -537,9 +540,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -554,9 +557,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -571,9 +574,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -588,9 +591,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -605,9 +608,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -622,9 +625,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +642,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -656,9 +659,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -673,9 +676,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -690,9 +693,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -707,9 +710,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -724,9 +727,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -741,9 +744,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -758,9 +761,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -775,9 +778,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -792,9 +795,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -809,9 +812,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -825,10 +828,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -843,9 +863,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -860,9 +880,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -877,9 +897,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -2411,9 +2431,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -2439,9 +2459,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2457,9 +2477,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@secretlint/config-creator": {
@@ -3253,9 +3273,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3918,9 +3938,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3931,31 +3951,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -4003,9 +4024,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -4119,6 +4140,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4235,9 +4271,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4793,9 +4829,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5407,9 +5443,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5417,6 +5453,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
+      "integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {
@@ -5427,6 +5508,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postgres-array": {
@@ -5498,22 +5589,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
+      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -6439,9 +6530,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cursor-rtl",
   "displayName": "Cursor RTL",
   "description": "Smart multi-language RTL support for Cursor AI Chat. Uses a purpose-built algorithm that auto-detects text direction per element - Hebrew, Arabic and Persian text is right-aligned while English stays left-aligned.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "publisher": "motcke",
   "license": "Apache-2.0",
   "icon": "resources/icon.png",
@@ -14,16 +14,44 @@
   "engines": {
     "vscode": "^1.85.0"
   },
-  "categories": ["Other"],
-  "keywords": ["rtl", "arabic", "hebrew", "persian", "cursor", "chat", "right-to-left"],
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "rtl",
+    "arabic",
+    "hebrew",
+    "persian",
+    "cursor",
+    "chat",
+    "right-to-left"
+  ],
   "main": "./dist/extension.js",
-  "activationEvents": ["onStartupFinished"],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "contributes": {
     "commands": [
-      { "command": "cursorRtl.enable", "title": "Cursor RTL: Enable RTL Support" },
-      { "command": "cursorRtl.disable", "title": "Cursor RTL: Disable RTL Support" },
-      { "command": "cursorRtl.status", "title": "Cursor RTL: Check Status" },
-      { "command": "cursorRtl.reapply", "title": "Cursor RTL: Re-apply After Update" }
+      {
+        "command": "cursorRtl.enable",
+        "title": "Cursor RTL: Enable RTL Support"
+      },
+      {
+        "command": "cursorRtl.disable",
+        "title": "Cursor RTL: Disable RTL Support"
+      },
+      {
+        "command": "cursorRtl.status",
+        "title": "Cursor RTL: Check Status"
+      },
+      {
+        "command": "cursorRtl.reapply",
+        "title": "Cursor RTL: Re-apply After Update"
+      },
+      {
+        "command": "cursorRtl.checkForUpdates",
+        "title": "Cursor RTL: Check for Extension Updates"
+      }
     ],
     "configuration": {
       "title": "Cursor RTL",
@@ -37,6 +65,23 @@
           "type": "boolean",
           "default": true,
           "description": "Show RTL status indicator in the status bar"
+        },
+        "cursorRtl.checkForExtensionUpdates": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically check GitHub releases for Cursor RTL extension updates"
+        },
+        "cursorRtl.updateCheckIntervalHours": {
+          "type": "number",
+          "default": 6,
+          "minimum": 1,
+          "description": "How often to check for Cursor RTL extension updates while Cursor is open"
+        },
+        "cursorRtl.updateRemindLaterHours": {
+          "type": "number",
+          "default": 24,
+          "minimum": 1,
+          "description": "How long to wait before showing the same update again after choosing Remind Later"
         }
       }
     }
@@ -46,13 +91,20 @@
     "watch": "node esbuild.js --watch",
     "package": "npm run build && vsce package --no-dependencies",
     "lint": "tsc --noEmit",
-    "vscode:uninstall": "node dist/uninstall.js"
+    "vscode:uninstall": "node dist/uninstall.js",
+    "visual:capture": "node scripts/visual-cursor-capture.mjs",
+    "visual:compare": "node scripts/visual-cursor-compare.mjs",
+    "visual:approve": "node scripts/visual-cursor-compare.mjs --update-baseline",
+    "visual": "npm run visual:capture && npm run visual:compare"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
     "@vscode/vsce": "^3.0.0",
-    "esbuild": "^0.24.0",
+    "esbuild": "^0.28.0",
+    "pixelmatch": "^7.2.0",
+    "playwright": "^1.59.1",
+    "pngjs": "^7.0.0",
     "typescript": "^5.5.0"
   },
   "dependencies": {

--- a/resources/rtl.js
+++ b/resources/rtl.js
@@ -38,6 +38,10 @@
             border-radius: 4px;
         }
 
+        .markdown-root table,
+        .markdown-section table,
+        .markdown-lexical-editor-container table,
+        .composer-rendered-message table,
         table.markdown-table {
             direction: rtl !important;
             width: max-content !important;
@@ -45,9 +49,18 @@
             border-collapse: collapse !important;
         }
 
+        .markdown-root table th,
+        .markdown-root table td,
+        .markdown-section table th,
+        .markdown-section table td,
+        .markdown-lexical-editor-container table th,
+        .markdown-lexical-editor-container table td,
+        .composer-rendered-message table th,
+        .composer-rendered-message table td,
         .markdown-table th,
         .markdown-table td {
-            text-align: right !important;
+            unicode-bidi: plaintext !important;
+            text-align: start !important;
             border: 1px solid var(--vscode-textSeparator-foreground) !important;
             padding: 6px 10px !important;
         }
@@ -154,6 +167,16 @@
         '.markdown-root h5',
         '.markdown-root h6',
         '.markdown-root blockquote',
+        '.markdown-root table th',
+        '.markdown-root table td',
+        '.markdown-section table th',
+        '.markdown-section table td',
+        '.markdown-lexical-editor-container table th',
+        '.markdown-lexical-editor-container table td',
+        '.composer-rendered-message table th',
+        '.composer-rendered-message table td',
+        '.markdown-table th',
+        '.markdown-table td',
         '.composer-human-message p',
         '.composer-human-message div',
         '.aislash-editor-input p',

--- a/scripts/visual-cursor-capture.mjs
+++ b/scripts/visual-cursor-capture.mjs
@@ -1,0 +1,165 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const cdpUrl = process.env.CURSOR_CDP_URL ?? 'http://localhost:9222';
+const outputDir = path.resolve('visual', 'actual');
+const targetTitle = process.env.CURSOR_TARGET_TITLE ?? 'Cursor';
+
+function parseClip(value) {
+  if (!value) return null;
+
+  const parts = value.split(',').map((part) => Number(part.trim()));
+  if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
+    throw new Error('VISUAL_CLIP must be "x,y,width,height"');
+  }
+
+  const [x, y, width, height] = parts;
+  return { x, y, width, height };
+}
+
+async function getWorkbenchPage(context) {
+  const pages = context.pages();
+  const candidates = await Promise.all(
+    pages.map(async (page) => ({
+      page,
+      url: page.url(),
+      title: await page.title().catch(() => ''),
+    })),
+  );
+
+  const page =
+    candidates.find((candidate) => candidate.url.includes('workbench.html'))?.page ??
+    candidates.find((candidate) => candidate.title.includes(targetTitle))?.page ??
+    candidates.find((candidate) => candidate.url.includes('vscode-file://'))?.page;
+
+  if (!page) {
+    const targetList = candidates
+      .map((candidate) => `- ${candidate.title || '(untitled)'} ${candidate.url}`)
+      .join('\n');
+    throw new Error(`Could not find Cursor workbench target.\nAvailable targets:\n${targetList}`);
+  }
+
+  return page;
+}
+
+async function getViewport(page) {
+  return page.evaluate(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+    devicePixelRatio: window.devicePixelRatio,
+  }));
+}
+
+async function getInspection(page) {
+  return page.evaluate(() => {
+    const rtlText = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF]/;
+    const selectorGroups = {
+      injectedStyles: 'style',
+      markdown: '.markdown-root, .markdown-section',
+      composer: '.composer-human-message, .aislash-editor-input, .aislash-editor-input-readonly',
+      code: 'code, pre, .markdown-code-outer-container, .cursor-code-block-content',
+      tables: '.markdown-table-container, table.markdown-table',
+      plan: '.plan-editor, .tiptap.ProseMirror',
+    };
+
+    const selectors = Object.fromEntries(
+      Object.entries(selectorGroups).map(([name, selector]) => [
+        name,
+        document.querySelectorAll(selector).length,
+      ]),
+    );
+
+    const injected = Array.from(document.querySelectorAll('style')).some((style) =>
+      style.textContent?.includes('RTL Auto-Detection Active') ||
+      style.textContent?.includes('.markdown-table-container'),
+    );
+
+    const samples = Array.from(document.querySelectorAll('p, li, h1, h2, h3, blockquote, textarea'))
+      .filter((element) => rtlText.test(element.textContent || ''))
+      .slice(0, 10)
+      .map((element) => {
+        const styles = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName.toLowerCase(),
+          text: (element.textContent || '').trim().slice(0, 120),
+          dir: element.getAttribute('dir'),
+          computedDirection: styles.direction,
+          textAlign: styles.textAlign,
+          rect: {
+            x: Math.round(rect.x),
+            y: Math.round(rect.y),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          },
+        };
+      });
+
+    return {
+      title: document.title,
+      url: location.href,
+      injected,
+      selectors,
+      rtlSamples: samples,
+    };
+  });
+}
+
+async function main() {
+  await fs.mkdir(outputDir, { recursive: true });
+  console.warn(
+    'Privacy notice: visual capture writes Cursor screenshots and short visible RTL text samples to visual/actual.',
+  );
+
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const context = browser.contexts()[0];
+  if (!context) {
+    throw new Error(`Connected to ${cdpUrl}, but no browser contexts were found.`);
+  }
+
+  const page = await getWorkbenchPage(context);
+  await page.waitForLoadState('domcontentloaded').catch(() => {});
+  await page.waitForTimeout(Number(process.env.VISUAL_WAIT_MS ?? 1000));
+
+  const viewport = await getViewport(page);
+  const fullPath = path.join(outputDir, 'cursor-full.png');
+  await page.screenshot({ path: fullPath, scale: 'css' });
+
+  const customClip = parseClip(process.env.VISUAL_CLIP);
+  const rightPaneClip =
+    customClip ?? {
+      x: Math.round(viewport.width * 0.55),
+      y: 0,
+      width: Math.round(viewport.width * 0.45),
+      height: viewport.height,
+    };
+  const rightPanePath = path.join(outputDir, 'cursor-right-pane.png');
+  await page.screenshot({ path: rightPanePath, clip: rightPaneClip, scale: 'css' });
+
+  const inspection = {
+    capturedAt: new Date().toISOString(),
+    cdpUrl,
+    viewport,
+    rightPaneClip,
+    ...(await getInspection(page)),
+  };
+  const inspectionPath = path.join(outputDir, 'cursor-inspection.json');
+  await fs.writeFile(inspectionPath, `${JSON.stringify(inspection, null, 2)}\n`);
+
+  console.log(`Captured ${fullPath}`);
+  console.log(`Captured ${rightPanePath}`);
+  console.log(`Wrote ${inspectionPath}`);
+  console.log(`RTL script detected: ${inspection.injected ? 'yes' : 'no'}`);
+  console.log(`RTL text samples found: ${inspection.rtlSamples.length}`);
+}
+
+main()
+  .then(() => {
+    // Keep Cursor open; exit this helper after the CDP capture is complete.
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/visual-cursor-compare.mjs
+++ b/scripts/visual-cursor-compare.mjs
@@ -1,0 +1,129 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { PNG } from 'pngjs';
+
+const { default: pixelmatch } = await import('pixelmatch');
+
+const baselineDir = path.resolve('visual', 'baseline');
+const actualDir = path.resolve('visual', 'actual');
+const diffDir = path.resolve('visual', 'diff');
+const threshold = Number(process.env.VISUAL_THRESHOLD ?? 0.002);
+const updateBaseline = process.argv.includes('--update-baseline');
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPng(filePath) {
+  const buffer = await fs.readFile(filePath);
+  return PNG.sync.read(buffer);
+}
+
+async function listPngs(dir) {
+  if (!(await exists(dir))) return [];
+
+  const entries = await fs.readdir(dir);
+  return entries.filter((entry) => entry.endsWith('.png')).sort();
+}
+
+async function approveActuals() {
+  await fs.mkdir(baselineDir, { recursive: true });
+  const actualPngs = await listPngs(actualDir);
+  if (actualPngs.length === 0) {
+    throw new Error('No actual screenshots found. Run npm run visual:capture first.');
+  }
+
+  for (const fileName of actualPngs) {
+    await fs.copyFile(path.join(actualDir, fileName), path.join(baselineDir, fileName));
+    console.log(`Approved baseline ${fileName}`);
+  }
+}
+
+async function compareFile(fileName) {
+  const baselinePath = path.join(baselineDir, fileName);
+  const actualPath = path.join(actualDir, fileName);
+  const diffPath = path.join(diffDir, fileName);
+
+  if (!(await exists(actualPath))) {
+    return {
+      fileName,
+      passed: false,
+      reason: 'missing actual screenshot',
+    };
+  }
+
+  const baseline = await readPng(baselinePath);
+  const actual = await readPng(actualPath);
+
+  if (baseline.width !== actual.width || baseline.height !== actual.height) {
+    return {
+      fileName,
+      passed: false,
+      reason: `size changed from ${baseline.width}x${baseline.height} to ${actual.width}x${actual.height}`,
+    };
+  }
+
+  const diff = new PNG({ width: baseline.width, height: baseline.height });
+  const differentPixels = pixelmatch(
+    baseline.data,
+    actual.data,
+    diff.data,
+    baseline.width,
+    baseline.height,
+    { threshold: 0.1 },
+  );
+  const ratio = differentPixels / (baseline.width * baseline.height);
+
+  await fs.mkdir(diffDir, { recursive: true });
+  await fs.writeFile(diffPath, PNG.sync.write(diff));
+
+  return {
+    fileName,
+    passed: ratio <= threshold,
+    differentPixels,
+    ratio,
+    diffPath,
+  };
+}
+
+async function main() {
+  if (updateBaseline) {
+    await approveActuals();
+    return;
+  }
+
+  const baselinePngs = await listPngs(baselineDir);
+  if (baselinePngs.length === 0) {
+    throw new Error(
+      'No baseline screenshots found. Run npm run visual:capture, review visual/actual, then run npm run visual:approve.',
+    );
+  }
+
+  const results = [];
+  for (const fileName of baselinePngs) {
+    results.push(await compareFile(fileName));
+  }
+
+  for (const result of results) {
+    if (result.passed) {
+      console.log(`PASS ${result.fileName}`);
+    } else {
+      console.log(`FAIL ${result.fileName}: ${result.reason ?? `${(result.ratio * 100).toFixed(3)}% changed`}`);
+    }
+  }
+
+  const failed = results.filter((result) => !result.passed);
+  if (failed.length > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,6 +3,19 @@ import { TelemetryClient } from 'applicationinsights';
 
 
 let _client: TelemetryClient | undefined;
+const TELEMETRY_OPTOUT_ENV = [
+    'CURSOR_RTL_TELEMETRY_OPTOUT',
+    'CURSOR_RTL_DISABLE_TELEMETRY',
+];
+
+function isOptOutValue(value: string | undefined): boolean {
+    if (!value) return false;
+    return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function isTelemetryOptedOut(): boolean {
+    return TELEMETRY_OPTOUT_ENV.some((name) => isOptOutValue(process.env[name]));
+}
 
 function possibleErrorsInfo(extra?: Record<string, string>): Record<string, string> {
     let user = undefined;
@@ -26,6 +39,7 @@ export type InitOptions = {
 
 export function init(opts?: InitOptions): void {
     if (_client) return;
+    if (isTelemetryOptedOut()) return;
     try {
         const cs = 'InstrumentationKey=e516562a-c892-4da2-837b-fb746bfda335;IngestionEndpoint=https://israelcentral-0.in.applicationinsights.azure.com/;LiveEndpoint=https://israelcentral.livediagnostics.monitor.azure.com/;ApplicationId=37c0836b-66ae-4444-8339-2fbbc80e1a68';
         _client = new TelemetryClient(cs);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,15 +10,24 @@ import {
     getDryRunSummary,
     handlePermissionError,
 } from './patcher';
-import { checkForUpdates } from './updateChecker';
+import { checkForExtensionUpdate, UpdateCheckResult } from './updateChecker';
 import { init as initActions, action, error as actionError, dispose as disposeActions } from './actions';
 
 let statusBarItem: vscode.StatusBarItem;
 let fileWatcher: fs.FSWatcher | undefined;
 let blinkInterval: ReturnType<typeof setInterval> | undefined;
 let blinkTimeout: ReturnType<typeof setTimeout> | undefined;
+let startupUpdateCheckTimeout: ReturnType<typeof setTimeout> | undefined;
+let updateCheckInterval: ReturnType<typeof setInterval> | undefined;
 
 type PatchState = 'on' | 'off' | 'update-needed';
+type UpdateCheckMode = 'startup' | 'periodic' | 'manual';
+
+const STARTUP_UPDATE_CHECK_DELAY_MS = 5_000;
+const MS_PER_HOUR = 60 * 60 * 1000;
+const LAST_NOTIFIED_VERSION_KEY = 'cursorRtl.lastNotifiedExtensionVersion';
+const REMIND_LATER_VERSION_KEY = 'cursorRtl.updateRemindLaterVersion';
+const REMIND_LATER_UNTIL_KEY = 'cursorRtl.updateRemindLaterUntil';
 
 function getPatchState(mainJsPath: string): PatchState {
     if (!fs.existsSync(mainJsPath)) {
@@ -252,6 +261,138 @@ async function statusCommand(): Promise<void> {
     }
 }
 
+function getExtensionVersion(context: vscode.ExtensionContext): string {
+    const version = context.extension.packageJSON.version;
+    return typeof version === 'string' ? version : '0.0.0';
+}
+
+function getNumberSetting(name: string, defaultValue: number, minValue: number): number {
+    const config = vscode.workspace.getConfiguration('cursorRtl');
+    const value = config.get<number>(name, defaultValue);
+    return Math.max(minValue, Number.isFinite(value) ? value : defaultValue);
+}
+
+function getUpdateCheckConfig(): {
+    enabled: boolean;
+    intervalMs: number;
+    remindLaterMs: number;
+} {
+    const config = vscode.workspace.getConfiguration('cursorRtl');
+    return {
+        enabled: config.get<boolean>('checkForExtensionUpdates', true),
+        intervalMs: getNumberSetting('updateCheckIntervalHours', 6, 1) * MS_PER_HOUR,
+        remindLaterMs: getNumberSetting('updateRemindLaterHours', 24, 1) * MS_PER_HOUR,
+    };
+}
+
+async function showExtensionUpdateNotification(
+    context: vscode.ExtensionContext,
+    result: Extract<UpdateCheckResult, { status: 'updateAvailable' }>,
+    mode: UpdateCheckMode,
+    remindLaterMs: number
+): Promise<void> {
+    if (mode !== 'manual') {
+        const lastNotifiedVersion = context.globalState.get<string>(LAST_NOTIFIED_VERSION_KEY);
+        const remindLaterVersion = context.globalState.get<string>(REMIND_LATER_VERSION_KEY);
+        const remindLaterUntil = context.globalState.get<number>(REMIND_LATER_UNTIL_KEY, 0);
+        const canRemindAgain =
+            remindLaterVersion === result.remoteVersion && Date.now() >= remindLaterUntil;
+
+        if (lastNotifiedVersion === result.remoteVersion && !canRemindAgain) {
+            return;
+        }
+
+        await context.globalState.update(LAST_NOTIFIED_VERSION_KEY, result.remoteVersion);
+    }
+
+    action('version_available', { mode, version: result.remoteVersion });
+
+    const actions = ['Open Release Page'];
+    if (result.vsixDownloadUrl) {
+        actions.push('Download VSIX');
+    }
+    actions.push('Remind Later');
+
+    const message =
+        `Cursor RTL: A new version is available (${result.remoteVersion}). Update now?`;
+    const choice = await vscode.window.showInformationMessage(message, ...actions);
+
+    if (choice === 'Open Release Page') {
+        action('update_action_release_page', { mode, version: result.remoteVersion });
+        await context.globalState.update(REMIND_LATER_UNTIL_KEY, undefined);
+        await vscode.env.openExternal(vscode.Uri.parse(result.releaseUrl));
+    } else if (choice === 'Download VSIX' && result.vsixDownloadUrl) {
+        action('update_action_download_vsix', { mode, version: result.remoteVersion });
+        await context.globalState.update(REMIND_LATER_UNTIL_KEY, undefined);
+        await vscode.env.openExternal(vscode.Uri.parse(result.vsixDownloadUrl));
+    } else if (choice === 'Remind Later') {
+        action('update_action_remind_later', { mode, version: result.remoteVersion });
+        await context.globalState.update(REMIND_LATER_VERSION_KEY, result.remoteVersion);
+        await context.globalState.update(REMIND_LATER_UNTIL_KEY, Date.now() + remindLaterMs);
+    }
+}
+
+async function runExtensionUpdateCheck(
+    context: vscode.ExtensionContext,
+    mode: UpdateCheckMode
+): Promise<void> {
+    const config = getUpdateCheckConfig();
+    if (!config.enabled && mode !== 'manual') {
+        return;
+    }
+
+    action('update_check_started', { mode });
+    const result = await checkForExtensionUpdate(getExtensionVersion(context));
+
+    if (result.status === 'failed') {
+        action('update_check_failed', { mode, error: result.error });
+        if (mode === 'manual') {
+            vscode.window.showWarningMessage(
+                `Cursor RTL: Could not check for extension updates. ${result.error}`
+            );
+        }
+        return;
+    }
+
+    if (result.status === 'upToDate') {
+        if (mode === 'manual') {
+            const version = result.remoteVersion ?? result.currentVersion;
+            vscode.window.showInformationMessage(`Cursor RTL is up to date (${version}).`);
+        }
+        return;
+    }
+
+    await showExtensionUpdateNotification(context, result, mode, config.remindLaterMs);
+}
+
+function clearScheduledUpdateChecks(): void {
+    if (startupUpdateCheckTimeout) {
+        clearTimeout(startupUpdateCheckTimeout);
+        startupUpdateCheckTimeout = undefined;
+    }
+    if (updateCheckInterval) {
+        clearInterval(updateCheckInterval);
+        updateCheckInterval = undefined;
+    }
+}
+
+function scheduleExtensionUpdateChecks(context: vscode.ExtensionContext): void {
+    clearScheduledUpdateChecks();
+
+    const config = getUpdateCheckConfig();
+    if (!config.enabled) {
+        return;
+    }
+
+    startupUpdateCheckTimeout = setTimeout(() => {
+        void runExtensionUpdateCheck(context, 'startup');
+    }, STARTUP_UPDATE_CHECK_DELAY_MS);
+
+    updateCheckInterval = setInterval(() => {
+        void runExtensionUpdateCheck(context, 'periodic');
+    }, config.intervalMs);
+}
+
 async function reapplyCommand(context: vscode.ExtensionContext): Promise<void> {
     const validation = validatePaths();
     if (!validation.valid) {
@@ -373,6 +514,12 @@ export function activate(context: vscode.ExtensionContext): void {
         )
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand('cursorRtl.checkForUpdates', () =>
+            runExtensionUpdateCheck(context, 'manual')
+        )
+    );
+
     const mainJsPath = getMainJsPath();
     const state = getPatchState(mainJsPath);
 
@@ -391,15 +538,19 @@ export function activate(context: vscode.ExtensionContext): void {
             const currentState = getPatchState(mainJsPath);
             updateStatusBar(currentState);
         }
+        if (
+            e.affectsConfiguration('cursorRtl.checkForExtensionUpdates') ||
+            e.affectsConfiguration('cursorRtl.updateCheckIntervalHours') ||
+            e.affectsConfiguration('cursorRtl.updateRemindLaterHours')
+        ) {
+            scheduleExtensionUpdateChecks(context);
+        }
     }, null, context.subscriptions);
 
     const mainJsState = getPatchState(mainJsPath);
     action('ext_start', { state: mainJsState, platform: process.platform });
 
-    const extensionVersion = context.extension.packageJSON.version as string;
-    checkForUpdates(extensionVersion).then((found) => {
-        if (found) action('version_available');
-    }).catch(() => {});
+    scheduleExtensionUpdateChecks(context);
 }
 
 export function deactivate(): Promise<void> {
@@ -416,5 +567,6 @@ export function deactivate(): Promise<void> {
         fileWatcher.close();
         fileWatcher = undefined;
     }
+    clearScheduledUpdateChecks();
     return disposeActions().catch(() => {});
 }

--- a/src/updateChecker.ts
+++ b/src/updateChecker.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import * as https from 'https';
 
 const GITHUB_REPO = 'motcke/cursor-ext-rtl';
 const RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+const RELEASES_LATEST_URL = `https://github.com/${GITHUB_REPO}/releases/latest`;
 
 interface GitHubAsset {
     name: string;
@@ -15,8 +15,34 @@ interface GitHubRelease {
     assets: GitHubAsset[];
 }
 
+export type UpdateCheckResult =
+    | {
+        status: 'updateAvailable';
+        currentVersion: string;
+        remoteVersion: string;
+        releaseUrl: string;
+        vsixDownloadUrl?: string;
+    }
+    | {
+        status: 'upToDate';
+        currentVersion: string;
+        remoteVersion?: string;
+        releaseUrl?: string;
+    }
+    | {
+        status: 'failed';
+        currentVersion: string;
+        error: string;
+    };
+
 function parseVersion(tag: string): number[] {
-    return tag.replace(/^v/, '').split('.').map(Number);
+    return tag
+        .replace(/^v/i, '')
+        .split('.')
+        .map((part) => {
+            const match = part.match(/^\d+/);
+            return match ? Number(match[0]) : 0;
+        });
 }
 
 function isNewer(remote: string, local: string): boolean {
@@ -83,36 +109,36 @@ function collectResponse(
     res.on('error', reject);
 }
 
-export async function checkForUpdates(currentVersion: string): Promise<boolean> {
+export async function checkForExtensionUpdate(currentVersion: string): Promise<UpdateCheckResult> {
     let release: GitHubRelease;
     try {
         release = await fetchLatestRelease();
-    } catch {
-        return false;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+            status: 'failed',
+            currentVersion,
+            error: message,
+        };
     }
 
     if (!release.tag_name || !isNewer(release.tag_name, currentVersion)) {
-        return false;
+        return {
+            status: 'upToDate',
+            currentVersion,
+            remoteVersion: release.tag_name?.replace(/^v/i, ''),
+            releaseUrl: release.html_url || RELEASES_LATEST_URL,
+        };
     }
 
     const vsixAsset = release.assets.find((a) => a.name.endsWith('.vsix'));
-    const remoteVersion = release.tag_name.replace(/^v/, '');
+    const remoteVersion = release.tag_name.replace(/^v/i, '');
 
-    const message = `Cursor RTL: A new version is available (${remoteVersion}). Update now?`;
-
-    const actions: string[] = [];
-    if (vsixAsset) {
-        actions.push('Download VSIX');
-    }
-    actions.push('Open Release Page');
-
-    const choice = await vscode.window.showInformationMessage(message, ...actions);
-
-    if (choice === 'Download VSIX' && vsixAsset) {
-        vscode.env.openExternal(vscode.Uri.parse(vsixAsset.browser_download_url));
-    } else if (choice === 'Open Release Page') {
-        vscode.env.openExternal(vscode.Uri.parse(release.html_url));
-    }
-
-    return true;
+    return {
+        status: 'updateAvailable',
+        currentVersion,
+        remoteVersion,
+        releaseUrl: release.html_url || RELEASES_LATEST_URL,
+        vsixDownloadUrl: vsixAsset?.browser_download_url,
+    };
 }

--- a/visual/README.md
+++ b/visual/README.md
@@ -1,0 +1,61 @@
+# Cursor Visual Checks
+
+These checks attach to a running Cursor window through Chrome DevTools Protocol and capture the real Cursor UI.
+
+## Privacy Notice
+
+Visual captures can include private information visible in Cursor. The capture command writes screenshots of the Cursor window and `cursor-inspection.json`, which includes the page URL/title and short RTL text samples from visible UI elements. Review `visual/actual` before sharing it.
+
+## Capture
+
+Start Cursor with CDP enabled:
+
+```powershell
+& "$env:LOCALAPPDATA\Programs\cursor\Cursor.exe" --remote-debugging-port=9222
+```
+
+Then capture screenshots:
+
+```powershell
+npm run visual:capture
+```
+
+This writes:
+
+- `visual/actual/cursor-full.png`
+- `visual/actual/cursor-right-pane.png`
+- `visual/actual/cursor-inspection.json`
+
+By default, `cursor-right-pane.png` captures the right 45% of the Cursor window. To capture a more precise area:
+
+```powershell
+$env:VISUAL_CLIP = "900,80,700,900"
+npm run visual:capture
+Remove-Item Env:\VISUAL_CLIP
+```
+
+## Approve Baseline
+
+After reviewing `visual/actual`, approve the current screenshots as the baseline:
+
+```powershell
+npm run visual:approve
+```
+
+## Compare
+
+After future changes:
+
+```powershell
+npm run visual
+```
+
+If the screenshots changed beyond the threshold, diffs are written to `visual/diff`.
+
+The default allowed difference is `0.2%`. Override it with:
+
+```powershell
+$env:VISUAL_THRESHOLD = "0.005"
+npm run visual:compare
+Remove-Item Env:\VISUAL_THRESHOLD
+```


### PR DESCRIPTION
Add Markdown table RTL fix, extension update flow, and visual regression tooling

Bring mixed Hebrew/English Markdown tables back to a correct layout via per-cell unicode-bidi handling, refactor the extension update checker into a structured flow with startup/periodic/manual modes and Release Page / Download VSIX / Remind Later actions, and add a CDP-based visual capture/compare workflow under scripts/ and visual/. Bumps version to 1.1.3 and documents the new commands and settings.