### PR TITLE
Add RTL support for the file editor (Monaco)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Smart multi-language RTL support for [Cursor](https://cursor.com) AI Chat, Agent
 ## Features
 
 - **Smart multi-language algorithm** - detects text direction per element using weighted RTL/LTR scoring, so Hebrew, Arabic and Persian content is right-aligned while English-heavy content stays left-aligned
+- **File editor (Monaco) RTL** - the same per-file detection extends to the code/Markdown editor: RTL-dominant files flow right-to-left (with the vertical scrollbar moved to the left and left/right arrow keys swapped to match), while English and code editors stay untouched. Choose `auto` / `always` / `off` via setting or quick-pick
 - **One-click Enable/Disable** via Command Palette
 - **Status Bar indicator** showing current RTL patch state (ON / OFF / UPDATE NEEDED)
 - **Automatic update detection** when Cursor updates overwrite `main.js`
@@ -51,6 +52,7 @@ Smart multi-language RTL support for [Cursor](https://cursor.com) AI Chat, Agent
 | `Cursor RTL: Check Status` | Show whether the RTL patch is currently active |
 | `Cursor RTL: Re-apply After Update` | Re-apply patch after a Cursor update overwrote it |
 | `Cursor RTL: Check for Extension Updates` | Check GitHub releases for a newer extension version |
+| `Cursor RTL: Editor Direction (Auto / Always / Off)` | Choose how the file editor (Monaco) picks its direction |
 
 ## Status Bar
 
@@ -64,6 +66,7 @@ Click the status bar item for a quick-pick menu with available actions.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
+| `cursorRtl.editorRtl` | `auto` | File editor (Monaco) direction. `auto` follows each file's dominant language, `always` forces RTL, `off` leaves the editor untouched. Applies live to open windows |
 | `cursorRtl.autoReapply` | `false` | Automatically re-apply RTL patch when Cursor updates overwrite `main.js` |
 | `cursorRtl.showStatusBar` | `true` | Show RTL status indicator in the status bar |
 | `cursorRtl.checkForExtensionUpdates` | `true` | Automatically check GitHub releases for Cursor RTL extension updates |
@@ -100,6 +103,8 @@ The direction algorithm assigns an explicit `dir="rtl"` or `dir="ltr"` to matchi
 
 Plan files and the Agents Window side Plan view use Cursor's TipTap/ProseMirror rich-text editor. Because that editor owns and may rewrite its DOM, Plan content also gets generated CSS rules scoped to the active Plan editor instead of relying only on direct `dir` attributes.
 
+For the file editor (Monaco), the same scorer samples each editor's visible lines and, when RTL-dominant (or when `cursorRtl.editorRtl` is `always`), marks it with a `data-cursor-rtl-dir="rtl"` attribute. Scoped CSS then flips the view lines to RTL, moves the vertical scrollbar to the left, and reorders Monaco's per-token spans so leading list markers and punctuation land on the right. Because Monaco's cursor controller has no RTL mode, a small keydown handler swaps the left/right arrows (keeping Shift/Alt/Ctrl/Meta) only while a marked-RTL editor is focused. The chosen mode is written to `~/.cursor-rtl-config.json`, which the loader watches so changes apply live without a reload.
+
 ### Safety measures
 
 - **Timestamped backups**: Before any modification, `main.js` is backed up as `main.js.rtl-backup-<timestamp>`
@@ -122,6 +127,7 @@ This restores the original `main.js` from the backup and removes the copied load
 - Cursor updates may overwrite `main.js`, requiring re-application of the patch
 - The extension shows a "[Unsupported]" warning in Cursor's title bar (same as any extension that modifies app files, like Custom CSS extensions)
 - Requires write permissions to Cursor's app directory (may need Administrator/sudo on some systems)
+- File editor RTL is a styling + input layer on top of Monaco, which has no native RTL mode. Visual order and arrow-key movement are corrected, but deeply mixed bidi lines can still have edge cases, and the line-number gutter stays on the left (moving it detaches Monaco's line-number positioning)
 
 ## Supported Cursor Versions
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Smart multi-language RTL support for [Cursor](https://cursor.com) AI Chat, Agent
 ## Features
 
 - **Smart multi-language algorithm** - detects text direction per element using weighted RTL/LTR scoring, so Hebrew, Arabic and Persian content is right-aligned while English-heavy content stays left-aligned
-- **File editor (Monaco) RTL** - the same per-file detection extends to the code/Markdown editor: RTL-dominant files flow right-to-left (with the vertical scrollbar moved to the left and left/right arrow keys swapped to match), while English and code editors stay untouched. Choose `auto` / `always` / `off` via setting or quick-pick
+- **Code editor (Monaco) RTL** - the same per-file detection extends to the main editing pane (including Markdown and plain-text files): RTL-dominant files flow right-to-left (with the vertical scrollbar moved to the left and left/right arrow keys swapped to match), while English and code files stay untouched. Choose `auto` / `always` / `off` via setting or quick-pick
 - **One-click Enable/Disable** via Command Palette
 - **Status Bar indicator** showing current RTL patch state (ON / OFF / UPDATE NEEDED)
 - **Automatic update detection** when Cursor updates overwrite `main.js`
@@ -52,7 +52,7 @@ Smart multi-language RTL support for [Cursor](https://cursor.com) AI Chat, Agent
 | `Cursor RTL: Check Status` | Show whether the RTL patch is currently active |
 | `Cursor RTL: Re-apply After Update` | Re-apply patch after a Cursor update overwrote it |
 | `Cursor RTL: Check for Extension Updates` | Check GitHub releases for a newer extension version |
-| `Cursor RTL: Editor Direction (Auto / Always / Off)` | Choose how the file editor (Monaco) picks its direction |
+| `Cursor RTL: Code Editor Direction (Auto / Always / Off)` | Choose how the code editor (Monaco) — including Markdown/plain-text — picks its direction |
 
 ## Status Bar
 
@@ -66,7 +66,7 @@ Click the status bar item for a quick-pick menu with available actions.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `cursorRtl.editorRtl` | `auto` | File editor (Monaco) direction. `auto` follows each file's dominant language, `always` forces RTL, `off` leaves the editor untouched. Applies live to open windows |
+| `cursorRtl.editorRtl` | `auto` | Code editor (Monaco) direction — the main editing pane, including Markdown and plain-text files. `auto` follows each file's dominant language, `always` forces RTL, `off` leaves the editor untouched. Applies live to open windows |
 | `cursorRtl.autoReapply` | `false` | Automatically re-apply RTL patch when Cursor updates overwrite `main.js` |
 | `cursorRtl.showStatusBar` | `true` | Show RTL status indicator in the status bar |
 | `cursorRtl.checkForExtensionUpdates` | `true` | Automatically check GitHub releases for Cursor RTL extension updates |
@@ -103,7 +103,7 @@ The direction algorithm assigns an explicit `dir="rtl"` or `dir="ltr"` to matchi
 
 Plan files and the Agents Window side Plan view use Cursor's TipTap/ProseMirror rich-text editor. Because that editor owns and may rewrite its DOM, Plan content also gets generated CSS rules scoped to the active Plan editor instead of relying only on direct `dir` attributes.
 
-For the file editor (Monaco), the same scorer samples each editor's visible lines and, when RTL-dominant (or when `cursorRtl.editorRtl` is `always`), marks it with a `data-cursor-rtl-dir="rtl"` attribute. Scoped CSS then flips the view lines to RTL, moves the vertical scrollbar to the left, and reorders Monaco's per-token spans so leading list markers and punctuation land on the right. Because Monaco's cursor controller has no RTL mode, a small keydown handler swaps the left/right arrows (keeping Shift/Alt/Ctrl/Meta) only while a marked-RTL editor is focused. The chosen mode is written to `~/.cursor-rtl-config.json`, which the loader watches so changes apply live without a reload.
+For the code editor (Monaco) — the main editing pane, including Markdown and plain-text files — the same scorer samples each editor's visible lines and, when RTL-dominant (or when `cursorRtl.editorRtl` is `always`), marks it with a `data-cursor-rtl-dir="rtl"` attribute. Scoped CSS then flips the view lines to RTL, moves the vertical scrollbar to the left, and reorders Monaco's per-token spans so leading list markers and punctuation land on the right. Because Monaco's cursor controller has no RTL mode, a small keydown handler swaps the left/right arrows (keeping Shift/Alt/Ctrl/Meta) only while a marked-RTL editor is focused. The chosen mode is written to `~/.cursor-rtl-config.json`, which the loader watches so changes apply live without a reload.
 
 ### Safety measures
 
@@ -127,7 +127,7 @@ This restores the original `main.js` from the backup and removes the copied load
 - Cursor updates may overwrite `main.js`, requiring re-application of the patch
 - The extension shows a "[Unsupported]" warning in Cursor's title bar (same as any extension that modifies app files, like Custom CSS extensions)
 - Requires write permissions to Cursor's app directory (may need Administrator/sudo on some systems)
-- File editor RTL is a styling + input layer on top of Monaco, which has no native RTL mode. Visual order and arrow-key movement are corrected, but deeply mixed bidi lines can still have edge cases, and the line-number gutter stays on the left (moving it detaches Monaco's line-number positioning)
+- Code editor RTL is a styling + input layer on top of Monaco, which has no native RTL mode. Visual order and arrow-key movement are corrected, but deeply mixed bidi lines can still have edge cases, and the line-number gutter stays on the left (moving it detaches Monaco's line-number positioning)
 
 ## Supported Cursor Versions
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       },
       {
         "command": "cursorRtl.setEditorRtl",
-        "title": "Cursor RTL: Editor Direction (Auto / Always / Off)"
+        "title": "Cursor RTL: Code Editor Direction (Auto / Always / Off)"
       }
     ],
     "configuration": {
@@ -68,12 +68,12 @@
             "off"
           ],
           "enumDescriptions": [
-            "Editor direction follows each file's dominant language: Hebrew/Arabic/Persian files flow RTL, English and code stay LTR",
-            "Force every file editor to right-to-left",
-            "Never change the file editor's direction"
+            "Code editor direction follows each file's dominant language: Hebrew/Arabic/Persian files flow RTL, English and code stay LTR",
+            "Force every code editor to right-to-left",
+            "Never change the code editor's direction"
           ],
           "default": "auto",
-          "description": "Right-to-left direction for the file editor (Monaco). Applies live to open windows; no reload needed."
+          "description": "Right-to-left direction for the code editor — the main editing pane, including Markdown and plain-text files (Monaco). Applies live to open windows; no reload needed."
         },
         "cursorRtl.autoReapply": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -51,11 +51,30 @@
       {
         "command": "cursorRtl.checkForUpdates",
         "title": "Cursor RTL: Check for Extension Updates"
+      },
+      {
+        "command": "cursorRtl.setEditorRtl",
+        "title": "Cursor RTL: Editor Direction (Auto / Always / Off)"
       }
     ],
     "configuration": {
       "title": "Cursor RTL",
       "properties": {
+        "cursorRtl.editorRtl": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "always",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Editor direction follows each file's dominant language: Hebrew/Arabic/Persian files flow RTL, English and code stay LTR",
+            "Force every file editor to right-to-left",
+            "Never change the file editor's direction"
+          ],
+          "default": "auto",
+          "description": "Right-to-left direction for the file editor (Monaco). Applies live to open windows; no reload needed."
+        },
         "cursorRtl.autoReapply": {
           "type": "boolean",
           "default": false,

--- a/resources/cursor-rtl-loader.cjs
+++ b/resources/cursor-rtl-loader.cjs
@@ -7,6 +7,16 @@
     var LOG_PREFIX = "[Cursor RTL Loader]";
     var homeDir = os.homedir();
     var LOG_FILE = path.join(homeDir, "cursor-rtl.log");
+    var CONFIG_FILE = path.join(homeDir, ".cursor-rtl-config.json");
+
+    function readConfig() {
+        try {
+            var raw = fs.readFileSync(CONFIG_FILE, "utf-8");
+            var parsed = JSON.parse(raw);
+            if (parsed && typeof parsed === "object") return parsed;
+        } catch (e) {}
+        return { editorRtl: "auto" };
+    }
 
     function log() {
         var args = Array.prototype.slice.call(arguments);
@@ -80,8 +90,10 @@
             return;
         }
         var script = fs.readFileSync(rtlPath, "utf-8");
-        log(label, "calling executeJavaScript, script length:", script.length);
-        wc.executeJavaScript(script)
+        var cfg = readConfig();
+        var configScript = "window.__cursorRtlConfig = " + JSON.stringify(cfg) + ";\n";
+        log(label, "calling executeJavaScript, script length:", script.length, "editorRtl:", cfg.editorRtl);
+        wc.executeJavaScript(configScript + script)
             .then(function() { return isRtlRuntimeAlive(wc); })
             .then(function(alive) {
                 wc.__rtlInjecting = false;
@@ -201,6 +213,49 @@
         }
     } catch (e) {
         log("getAllWindows error:", e.message);
+    }
+
+    // Live-push editor RTL mode changes to open workbench windows so toggling
+    // the setting/quick-pick applies without a reload.
+    function pushEditorMode(mode) {
+        try {
+            var wins = electron.BrowserWindow.getAllWindows();
+            for (var i = 0; i < wins.length; i++) {
+                (function(win) {
+                    try {
+                        var wc = win.webContents;
+                        if (!wc || wc.isDestroyed()) return;
+                        var url = wc.getURL ? wc.getURL() : "";
+                        if (!isWorkbenchUrl(url)) return;
+                        wc.executeJavaScript(
+                            "window.__cursorRtlSetEditorMode && window.__cursorRtlSetEditorMode(" +
+                            JSON.stringify(mode) + ")"
+                        ).catch(function() {});
+                    } catch (e) {}
+                })(wins[i]);
+            }
+        } catch (e) {
+            log("pushEditorMode error:", e.message);
+        }
+    }
+
+    try {
+        if (!fs.existsSync(CONFIG_FILE)) {
+            fs.writeFileSync(CONFIG_FILE, JSON.stringify({ editorRtl: "auto" }));
+        }
+        var configWatchTimer = null;
+        fs.watch(CONFIG_FILE, function() {
+            if (configWatchTimer) return;
+            configWatchTimer = setTimeout(function() {
+                configWatchTimer = null;
+                var cfg = readConfig();
+                log("config changed, pushing editorRtl:", cfg.editorRtl);
+                pushEditorMode(cfg.editorRtl || "auto");
+            }, 150);
+        });
+        log("watching config file:", CONFIG_FILE);
+    } catch (e) {
+        log("config watch not active:", e.message);
     }
 
     log("loader setup complete.");

--- a/resources/rtl.js
+++ b/resources/rtl.js
@@ -580,6 +580,31 @@
             unicode-bidi: isolate !important;
             text-align: start !important;
         }
+
+        .monaco-editor[data-cursor-rtl-dir="rtl"] .view-lines {
+            direction: rtl !important;
+        }
+
+        .monaco-editor[data-cursor-rtl-dir="rtl"] .view-line {
+            text-align: right !important;
+            unicode-bidi: plaintext !important;
+        }
+
+        /* Monaco wraps each line's text in a <span dir="ltr"> with token spans
+           set to unicode-bidi: isolate. That explicit LTR base pins leading
+           list markers / punctuation / Latin runs to the left even on RTL
+           lines. Overriding the wrapper's direction reorders the isolated
+           token spans right-to-left, so "1." and friends land on the right. */
+        .monaco-editor[data-cursor-rtl-dir="rtl"] .view-line > span {
+            direction: rtl !important;
+        }
+
+        /* Move the vertical scrollbar to the left edge so it doesn't sit on
+           top of the RTL text's starting margin. */
+        .monaco-editor[data-cursor-rtl-dir="rtl"] .scrollbar.vertical {
+            left: 0 !important;
+            right: auto !important;
+        }
     `;
     document.head.appendChild(style);
     const planStyle = document.createElement('style');
@@ -1134,9 +1159,146 @@
         }
     }
 
+    // --- Editor RTL (file editor direction) --------------------------------
+    // Extends the same content detection used for chat/plan to Cursor's file
+    // editor (Monaco). For each open editor we sample its visible lines, run
+    // the shared getMajorityDir() scorer, and mark the editor RTL only when its
+    // content is RTL-dominant — English/code editors are left untouched, so
+    // this is safe to run automatically. A data attribute (not a class) is
+    // used because Monaco rewrites the editor element's className.
+    //
+    // Mode comes from window.__cursorRtlConfig.editorRtl at inject time and can
+    // be updated live by the loader via window.__cursorRtlSetEditorMode():
+    //   'auto'   – direction follows each editor's dominant language (default)
+    //   'always' – force every file editor RTL
+    //   'off'    – never touch the file editor
+    var EDITOR_EXCLUDE_SELECTOR = [
+        '.composer-rendered-message',
+        '.markdown-root',
+        '.markdown-section',
+        '.markdown-lexical-editor-container',
+        '.markdown-code-outer-container',
+        '.cursor-code-block-content',
+        '.plan-editor',
+        '.ui-plan-editor',
+        '.aislash-editor-input',
+        '.aislash-editor-input-readonly',
+        '.ui-prompt-input-editor__input',
+        '.ui-prompt-input-tiptap-readonly__content'
+    ].join(', ');
+
+    var EDITOR_LINE_SAMPLE = 80;
+    var editorMode = 'auto';
+    try {
+        if (window.__cursorRtlConfig && typeof window.__cursorRtlConfig.editorRtl === 'string') {
+            editorMode = window.__cursorRtlConfig.editorRtl;
+        }
+    } catch (e) {}
+
+    function normalizeEditorMode(mode) {
+        return (mode === 'auto' || mode === 'always' || mode === 'off') ? mode : 'auto';
+    }
+
+    function isFileEditor(editor) {
+        if (!editor || !editor.closest) return false;
+        // Skip chat/plan/markdown/code-block Monaco instances — those are
+        // handled elsewhere and should stay LTR.
+        return !editor.closest(EDITOR_EXCLUDE_SELECTOR);
+    }
+
+    function detectEditorDir(editor) {
+        var lines = editor.querySelectorAll('.view-line');
+        if (!lines.length) return 'ltr';
+        var sample = [];
+        var limit = Math.min(lines.length, EDITOR_LINE_SAMPLE);
+        for (var i = 0; i < limit; i++) {
+            sample.push(lines[i]);
+        }
+        return getMajorityDir(sample);
+    }
+
+    function setEditorDir(editor, dir) {
+        if (dir === 'rtl') {
+            if (editor.getAttribute('data-cursor-rtl-dir') !== 'rtl') {
+                editor.setAttribute('data-cursor-rtl-dir', 'rtl');
+            }
+        } else if (editor.hasAttribute('data-cursor-rtl-dir')) {
+            editor.removeAttribute('data-cursor-rtl-dir');
+        }
+    }
+
+    function applyEditorDir() {
+        var mode = normalizeEditorMode(editorMode);
+        var editors = document.querySelectorAll('.monaco-editor');
+        for (var i = 0; i < editors.length; i++) {
+            var editor = editors[i];
+            try {
+                if (mode === 'off' || !isFileEditor(editor)) {
+                    setEditorDir(editor, 'ltr');
+                    continue;
+                }
+                var dir = mode === 'always' ? 'rtl' : detectEditorDir(editor);
+                setEditorDir(editor, dir);
+            } catch (e) {}
+        }
+    }
+
+    window.__cursorRtlSetEditorMode = function(mode) {
+        editorMode = normalizeEditorMode(mode);
+        console.log(RTL_LOG, 'editor RTL mode:', editorMode);
+        scanAll();
+        return editorMode;
+    };
+
+    // Monaco's cursor controller has no RTL mode: pressing the physical
+    // left/right arrow always moves by *logical* character order, which reads
+    // backwards once we've flipped a line's visuals to RTL. We swap the two
+    // horizontal arrows (preserving Shift/Alt/Ctrl/Meta modifiers) but only
+    // while the focused editor is one we marked RTL, so LTR/code editors keep
+    // their native behaviour. Installed once; guarded against re-injection.
+    function installArrowSwap() {
+        if (window.__cursorRtlArrowSwapInstalled) return;
+        window.__cursorRtlArrowSwapInstalled = true;
+        document.addEventListener('keydown', function(e) {
+            try {
+                if (e.__cursorRtlSwapped) return;
+                if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+                if (!e.target || !e.target.closest) return;
+                var editor = e.target.closest('.monaco-editor[data-cursor-rtl-dir="rtl"]');
+                if (!editor) return;
+                var textarea = editor.querySelector('textarea.inputarea');
+                if (!textarea) return;
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                var toRight = e.key === 'ArrowLeft';
+                var swapKey = toRight ? 'ArrowRight' : 'ArrowLeft';
+                var swapCode = toRight ? 39 : 37;
+                var swapped = new KeyboardEvent('keydown', {
+                    key: swapKey,
+                    code: swapKey,
+                    bubbles: true,
+                    cancelable: true,
+                    shiftKey: e.shiftKey,
+                    altKey: e.altKey,
+                    ctrlKey: e.ctrlKey,
+                    metaKey: e.metaKey
+                });
+                // KeyboardEvent's constructor ignores keyCode/which; Monaco
+                // reads them, so define them explicitly.
+                Object.defineProperty(swapped, 'keyCode', { get: function() { return swapCode; } });
+                Object.defineProperty(swapped, 'which', { get: function() { return swapCode; } });
+                swapped.__cursorRtlSwapped = true;
+                textarea.dispatchEvent(swapped);
+            } catch (err) {}
+        }, true);
+        console.log(RTL_LOG, 'arrow-key swap installed for RTL editors');
+    }
+    // --- end Editor RTL ----------------------------------------------------
+
     function scanAll() {
         scanRoot(document);
         applyPlanDir();
+        applyEditorDir();
         try {
             walkShadows(document.documentElement, scanRoot);
         } catch (e) {}
@@ -1158,6 +1320,7 @@
 
     attachObserver(document.documentElement);
     attachAllCurrentShadowObservers();
+    installArrowSwap();
     scanAll();
     scheduleScan();
     setTimeout(function() {

--- a/resources/rtl.js
+++ b/resources/rtl.js
@@ -1159,8 +1159,8 @@
         }
     }
 
-    // --- Editor RTL (file editor direction) --------------------------------
-    // Extends the same content detection used for chat/plan to Cursor's file
+    // --- Editor RTL (code editor direction) --------------------------------
+    // Extends the same content detection used for chat/plan to Cursor's code
     // editor (Monaco). For each open editor we sample its visible lines, run
     // the shared getMajorityDir() scorer, and mark the editor RTL only when its
     // content is RTL-dominant — English/code editors are left untouched, so
@@ -1170,8 +1170,8 @@
     // Mode comes from window.__cursorRtlConfig.editorRtl at inject time and can
     // be updated live by the loader via window.__cursorRtlSetEditorMode():
     //   'auto'   – direction follows each editor's dominant language (default)
-    //   'always' – force every file editor RTL
-    //   'off'    – never touch the file editor
+    //   'always' – force every code editor RTL
+    //   'off'    – never touch the code editor
     var EDITOR_EXCLUDE_SELECTOR = [
         '.composer-rendered-message',
         '.markdown-root',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { validatePaths, getMainJsPath, getAppOutDir } from './paths';
+import { validatePaths, getMainJsPath, getAppOutDir, getConfigPath } from './paths';
 import {
     isPatched,
     hasBackups,
@@ -121,6 +121,11 @@ async function showQuickPick(): Promise<void> {
         });
     }
 
+    items.push({
+        label: '$(text-size) Editor Direction',
+        description: `Currently: ${getEditorRtlMode()}`,
+    });
+
     const picked = await vscode.window.showQuickPick(items, {
         placeHolder: 'Cursor RTL',
     });
@@ -135,9 +140,59 @@ async function showQuickPick(): Promise<void> {
         await vscode.commands.executeCommand('cursorRtl.disable');
     } else if (picked.label.includes('Re-apply')) {
         await vscode.commands.executeCommand('cursorRtl.reapply');
+    } else if (picked.label.includes('Editor Direction')) {
+        await vscode.commands.executeCommand('cursorRtl.setEditorRtl');
     } else if (picked.label.includes('Status')) {
         await vscode.commands.executeCommand('cursorRtl.status');
     }
+}
+
+type EditorRtlMode = 'auto' | 'always' | 'off';
+
+function getEditorRtlMode(): EditorRtlMode {
+    const value = vscode.workspace
+        .getConfiguration('cursorRtl')
+        .get<string>('editorRtl', 'auto');
+    return value === 'always' || value === 'off' ? value : 'auto';
+}
+
+// Persist the editor-RTL mode where the injected loader can read it. The
+// loader watches this file and pushes changes live into open windows.
+function writeEditorConfig(): void {
+    try {
+        fs.writeFileSync(
+            getConfigPath(),
+            JSON.stringify({ editorRtl: getEditorRtlMode() })
+        );
+    } catch {
+        // Non-critical: the loader defaults to 'auto' when the file is absent.
+    }
+}
+
+async function setEditorRtlCommand(): Promise<void> {
+    const current = getEditorRtlMode();
+    const options: Array<{ label: string; description: string; mode: EditorRtlMode }> = [
+        { label: '$(sparkle) Auto', description: "Follow each file's dominant language", mode: 'auto' },
+        { label: '$(arrow-right) Always RTL', description: 'Force every file editor right-to-left', mode: 'always' },
+        { label: '$(circle-slash) Off', description: "Never change the editor's direction", mode: 'off' },
+    ];
+
+    const picked = await vscode.window.showQuickPick(
+        options.map((item) => ({
+            ...item,
+            label: item.mode === current ? `${item.label} $(check)` : item.label,
+        })),
+        { placeHolder: `Editor RTL direction (current: ${current})` }
+    );
+
+    if (!picked) {
+        return;
+    }
+
+    await vscode.workspace
+        .getConfiguration('cursorRtl')
+        .update('editorRtl', picked.mode, vscode.ConfigurationTarget.Global);
+    action('editor_rtl_set', { mode: picked.mode });
 }
 
 async function enableCommand(context: vscode.ExtensionContext): Promise<void> {
@@ -529,6 +584,14 @@ export function activate(context: vscode.ExtensionContext): void {
         )
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand('cursorRtl.setEditorRtl', () =>
+            setEditorRtlCommand()
+        )
+    );
+
+    writeEditorConfig();
+
     const mainJsPath = getMainJsPath();
     const state = getPatchState(mainJsPath);
 
@@ -552,6 +615,9 @@ export function activate(context: vscode.ExtensionContext): void {
             e.affectsConfiguration('cursorRtl.updateCheckIntervalHours')
         ) {
             scheduleExtensionUpdateChecks(context);
+        }
+        if (e.affectsConfiguration('cursorRtl.editorRtl')) {
+            writeEditorConfig();
         }
     }, null, context.subscriptions);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ async function showQuickPick(): Promise<void> {
     }
 
     items.push({
-        label: '$(text-size) Editor Direction',
+        label: '$(text-size) Code Editor Direction',
         description: `Currently: ${getEditorRtlMode()}`,
     });
 
@@ -173,8 +173,8 @@ async function setEditorRtlCommand(): Promise<void> {
     const current = getEditorRtlMode();
     const options: Array<{ label: string; description: string; mode: EditorRtlMode }> = [
         { label: '$(sparkle) Auto', description: "Follow each file's dominant language", mode: 'auto' },
-        { label: '$(arrow-right) Always RTL', description: 'Force every file editor right-to-left', mode: 'always' },
-        { label: '$(circle-slash) Off', description: "Never change the editor's direction", mode: 'off' },
+        { label: '$(arrow-right) Always RTL', description: 'Force every code editor right-to-left', mode: 'always' },
+        { label: '$(circle-slash) Off', description: "Never change the code editor's direction", mode: 'off' },
     ];
 
     const picked = await vscode.window.showQuickPick(
@@ -182,7 +182,7 @@ async function setEditorRtlCommand(): Promise<void> {
             ...item,
             label: item.mode === current ? `${item.label} $(check)` : item.label,
         })),
-        { placeHolder: `Editor RTL direction (current: ${current})` }
+        { placeHolder: `Code editor RTL direction (current: ${current})` }
     );
 
     if (!picked) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,6 +1,14 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
+
+// Shared runtime config file, read by the injected loader (main process) to
+// pass live settings into rtl.js. Kept in the home directory because both the
+// extension host and the Electron loader can reach it on every platform.
+export function getConfigPath(): string {
+    return path.join(os.homedir(), '.cursor-rtl-config.json');
+}
 
 export function getAppOutDir(): string {
     const appRoot = vscode.env.appRoot;


### PR DESCRIPTION
Hi! 👋 First off — thank you for this extension. The chat/plan RTL support has made Cursor genuinely usable for Hebrew work, and the per-element detection algorithm is lovely. This PR proposes extending that same idea to the **file editor (Monaco)** so `.md`/code files written in Hebrew/Arabic/Persian read naturally too. Totally understand if the scope or approach isn't what you want — happy to adjust anything.

## What it does

Let you edit MD files in Hebrew/Arabic/Persian with the same experience as with your chat RTL extension.

## Notes / honesty

- Monaco has no native RTL mode, so this is a styling + input layer. Visual order and arrow movement are corrected, but deeply mixed bidi lines may still have edge cases.
- The **line-number gutter is intentionally left on the left** — flipping it to the right detaches Monaco's line-number positioning (they vanish), so I didn't go there.
- I **left the version in `package.json` unchanged** so it fits your release flow — happy to bump it to whatever you prefer.
- README updated (Features, Commands, Settings, How It Works, Known Limitations).

## Testing

Manually tested on macOS with Hebrew Markdown (`SKILL.md`): auto-detection flips only RTL files, list numbers render on the right, scrollbar sits on the left, and ←/→/Shift+arrows/Option+arrows move as expected. English/code files are unaffected, and `auto`/`always`/`off` toggle live via the quick-pick.

Thanks again for the great extension — glad to iterate on any of this. 🙏
